### PR TITLE
Bump minimist from 1.2.5 to 1.2.6 in /integration-tests/runtime-tests

### DIFF
--- a/integration-tests/runtime-tests/package-lock.json
+++ b/integration-tests/runtime-tests/package-lock.json
@@ -24,7 +24,7 @@
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
         "chai-bn": "^0.3.1",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "mocha": "^9.2.2",
         "mochawesome": "^7.1.2",
         "npm-check-updates": "^12.5.3",
@@ -5898,9 +5898,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minipass": {
       "version": "3.1.6",
@@ -13902,9 +13902,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
       "version": "3.1.6",

--- a/integration-tests/runtime-tests/package.json
+++ b/integration-tests/runtime-tests/package.json
@@ -61,7 +61,7 @@
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
     "chai-bn": "^0.3.1",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.6",
     "mocha": "^9.2.2",
     "mochawesome": "^7.1.2",
     "npm-check-updates": "^12.5.3",


### PR DESCRIPTION
## Issue
*Please replace this line with either a link to the ClickUp issue, or a reference to the GitHub issue.*

## Description
*Please replace this line with info that is not in the ClickUp ticket, eg: "also bumps dependency foo version"*

## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_